### PR TITLE
Fix description HTML stripping

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,9 +50,6 @@ gem 'rails_admin'
 gem 'rmagick'
 gem 'paperclip'
 
-# Rails built-in truncate isn't good for HTML
-gem 'html_truncator'
-
 # Use puma as the app server
 gem 'puma'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,8 +86,6 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.6)
       tilt
-    html_truncator (0.4.1)
-      nokogiri (~> 1.5)
     i18n (0.7.0)
     jbuilder (2.3.0)
       activesupport (>= 3.0.0, < 5)
@@ -243,7 +241,6 @@ DEPENDENCIES
   factory_girl_rails
   ffaker
   foundation-rails
-  html_truncator
   jbuilder (~> 2.0)
   jquery-rails
   kaminari

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -9,7 +9,7 @@
     <div class="small-12 columns services-header">Our Next Event</div>
     <hr>
     <div class="small-12 columns main-event">
-      <%= render 'layouts/event_card', event: @highlighted_event, description_length: 20 %>
+      <%= render 'layouts/event_card', event: @highlighted_event, summary: true %>
     </div>
   <% end %>
   <% if type == 'All' %>
@@ -26,7 +26,7 @@
   <div class="row" data-equalizer data-equalizer-mq="medium-up">
     <% @events.each_with_index do |event, index| %>
       <div class="small-12 medium-4 columns end section" data-equalizer-watch>
-        <%= render 'layouts/event_card', event: event, description_length: 20  %>
+        <%= render 'layouts/event_card', event: event, summary: true %>
       </div>
     <% end %>
   </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,6 +7,6 @@
 </script>
 <div class="row content-container">
   <div class="small-12 columns main-event">
-    <%= render 'layouts/event_card', event: @event, description_length: 0 %>
+    <%= render 'layouts/event_card', event: @event, summary: false %>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -33,7 +33,7 @@
     <div class="small-12 columns services-header">Our Next Event</div>
     <hr>
     <div class="small-12 columns main-event">
-      <%= render 'layouts/event_card', event: @highlighted_event, description_length: 20 %>
+      <%= render 'layouts/event_card', event: @highlighted_event, summary: true %>
     </div>
   <% end %>
   <div class="small-12 columns services-header">Our Services</div>

--- a/app/views/layouts/_event_card.html.erb
+++ b/app/views/layouts/_event_card.html.erb
@@ -7,10 +7,10 @@
       <div class="date"><%= event.date.strftime "%-d %b %Y %H:%M" %></div>
     </div>
     <div class="text">
-      <% if(description_length == 0) %>
-        <%= event.description %>
+      <% if summary %>
+        <%= sanitize(event.description, tags: []).truncate_words(20) %>
       <% else %>
-        <%= HTML_Truncator.truncate(event.description, description_length).html_safe %>
+        <%= event.description.html_safe %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
HTML shows in event description pages
Cards now use summary boolean instead of explicit word length
