### PR TITLE
Disable send button while waiting on a response

### DIFF
--- a/app/views/layouts/_modal.html.erb
+++ b/app/views/layouts/_modal.html.erb
@@ -27,8 +27,8 @@
 
     <%= f.label :body %>
     <%= f.text_area :body, rows: 5, cols: 40, class: "textarea", placeholder: "Write your message here...", required: true %>
-    
-    <%= f.submit "Send" %>
+
+    <%= f.submit "Send", data: { disable_with: "Please wait..." } %>
 
     <a class="close-reveal-modal" aria-label="Close">&#215;</a>
   <% end %>


### PR DESCRIPTION
Yeah so there's been a few cases where we've gotten duplicate emails because it wasn't so obvious that they should wait to get back a "Sent" message. Now the submit button is disabled while the email is being sent.
