### PR TITLE
Mobile view improvements

### DIFF
--- a/app/assets/stylesheets/showcase.scss
+++ b/app/assets/stylesheets/showcase.scss
@@ -177,7 +177,12 @@
 
 @media screen and(max-width: $small-breakpoint) {
   .showcase-page {
+    .info {
+      width: 90%;
+    }
+    
     .accordion {
+      width: 98%;
       .showcase {
         .content {
           padding-top: 10px;
@@ -207,12 +212,11 @@
           .item-content {
             .meta {
               .owner {
-                margin-left: 40%;
                 display: block;
                 margin-right: -4px;
                 a {
                   margin-right: 3px;
-                  float: right;
+                  float: none;
                 }
               }
             }

--- a/app/views/showcase/_showcase_item.html.erb
+++ b/app/views/showcase/_showcase_item.html.erb
@@ -12,7 +12,7 @@
     </h3>
     <div class="meta">
       <p class="owner"><%= item.owner %>
-      <%= link_to truncate(URI.parse(item.link).host + URI.parse(item.link).path, length: 25, omission: '...'), item.link %></p>
+      <%= link_to truncate(URI.parse(item.link).host + URI.parse(item.link).path, length: 22, omission: '...'), item.link %></p>
     </div>
     <div class="text">
         <%= item.description.html_safe.truncate_words(40) %>


### PR DESCRIPTION
Improve the mobile view by increasing the width of showcase items and fixing the alignment of item owner names + links to get rid of nasty overflow.
